### PR TITLE
Add SQL*Plus as a dependency of DBD::Oracle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ RUN tmp_dir=$(mktemp -d /tmp/oracleclient.XXX) && \
     rpm -i ${tmp_dir}/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm && \
     rm -rf ${tmp_dir}
 
-ENV ORACLE_HOME /usr/lib/oracle/11.2/client64
+ENV ORACLE_HOME "/usr/lib/oracle/11.2/client64"
+ENV PATH "/usr/lib/oracle/11.2/client64/bin:${PATH}"
 
 # Install GoPAN
 ADD https://github.com/companieshouse/gopan/releases/download/${gopan_tag_version}/gopan-${gopan_version}-linux_amd64.tar.gz /gopan-${gopan_version}-linux_amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,10 @@ RUN gpg --verify /root/aws-cli.zip.sig /root/aws-cli.zip
 
 # Install AWS CLI
 RUN unzip /root/aws-cli.zip -d /root && \
-    /root/aws/install
+    /root/aws/install && \
+    rm -rf /root/aws*
 
-RUN rm -rf /root/aws*
-
+# Install Oracle Instant Client and sqlplus as a dependency of DBD::Oracle
 RUN tmp_dir=$(mktemp -d /tmp/oracleclient.XXX) && \
     aws2 s3 cp s3://resources.ch.gov.uk/packages/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm ${tmp_dir} && \
     aws2 s3 cp s3://resources.ch.gov.uk/packages/oracle/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm ${tmp_dir} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,9 @@ RUN rm -rf /root/aws*
 
 RUN tmp_dir=$(mktemp -d /tmp/oracleclient.XXX) && \
     aws2 s3 cp s3://resources.ch.gov.uk/packages/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm ${tmp_dir} && \
+    aws2 s3 cp s3://resources.ch.gov.uk/packages/oracle/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm ${tmp_dir} && \
     rpm -i ${tmp_dir}/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm && \
+    rpm -i ${tmp_dir}/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm && \
     rm -rf ${tmp_dir}
 
 ENV ORACLE_HOME /usr/lib/oracle/11.2/client64

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ ADD https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip /root/aws-
 ADD https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip.sig /root/aws-cli.zip.sig
 
 # Verify signature of AWS CLI package
-RUN gpg --import /root/aws-cli-team.pub
-RUN gpg --verify /root/aws-cli.zip.sig /root/aws-cli.zip
+RUN gpg --import /root/aws-cli-team.pub && \
+    gpg --verify /root/aws-cli.zip.sig /root/aws-cli.zip
 
 # Install AWS CLI
 RUN unzip /root/aws-cli.zip -d /root && \


### PR DESCRIPTION
These changes include:

* Install `sqplus` as a dependency of `DBD::Oracle` for identifying Oracle Instant Client version at build time
* Ensure `sqlplus` binary is reachable via `PATH` environment variable
* Flatten several layers created when verifying file signature and cleaning build artefacts from image