### PR TITLE
Add package for additional development headers and *.mk files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,10 @@ RUN unzip /root/aws-cli.zip -d /root && \
 RUN tmp_dir=$(mktemp -d /tmp/oracleclient.XXX) && \
     aws2 s3 cp s3://resources.ch.gov.uk/packages/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm ${tmp_dir} && \
     aws2 s3 cp s3://resources.ch.gov.uk/packages/oracle/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm ${tmp_dir} && \
+    aws2 s3 cp s3://resources.ch.gov.uk/packages/oracle/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm ${tmp_dir} && \
     rpm -i ${tmp_dir}/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm && \
     rpm -i ${tmp_dir}/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm && \
+    rpm -i ${tmp_dir}/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm && \
     rm -rf ${tmp_dir}
 
 ENV ORACLE_HOME "/usr/lib/oracle/11.2/client64"


### PR DESCRIPTION
A suitable `.mk` file and additional developer header files (i.e. `.h`) are required for the Oracle Instant Client to function when building CHS Perl-based projects that depend on `DBD::Oracle`. This change adds an additional `RPM` package to install the required files.