### PR TITLE
Set consistent plenv path to fix interpreter in generated binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,8 +108,6 @@ RUN plenv rehash
 
 RUN echo 'eval "$(plenv init -)"' >> ~/.bashrc
 
-RUN mkdir -p /opt/plenv/versions/${perl_version}/bin
-
 RUN bash -c "PERL_CPANM_OPT='--notest' PLENV_INSTALL_CPANM=' ' ${plenv_root}/bin/plenv install-cpanm"
 
 # Set system timezone

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,8 @@ RUN cd ${plenv_root}/plugins/perl-build && git checkout ${plenv_perlbuild_versio
 ENV PATH ${plenv_root}/bin:${plenv_root}/plugins/perl-build/bin:$PATH
 
 # Install Perl
+ENV PLENV_ROOT=${plenv_root}
+
 RUN plenv install ${perl_version} ${perl_build_args}
 
 RUN plenv global ${perl_version}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos6.6
 
-ARG plenv_root=/root/.plenv
+ARG plenv_root=/opt/.plenv
 ARG plenv_version=2.2.0
 ARG plenv_perlbuild_version=1.13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${nvm_version}/install
 ENV PATH /root/.nvm/versions/node/${node_js_version}/bin:$PATH
 
 # Install plenv and Perl Build
-RUN git clone https://github.com/tokuhirom/plenv.git ${plenv_root}
+RUN mkdir -p ${plenv_root} && git clone https://github.com/tokuhirom/plenv.git ${plenv_root}
 
 RUN cd ${plenv_root} && git checkout ${plenv_version}
 
@@ -109,8 +109,6 @@ RUN plenv rehash
 RUN echo 'eval "$(plenv init -)"' >> ~/.bashrc
 
 RUN mkdir -p /opt/plenv/versions/${perl_version}/bin
-
-RUN ln -s /root/.plenv/shims/perl${perl_version} /opt/plenv/versions/${perl_version}/bin/perl${perl_version}
 
 RUN bash -c "PERL_CPANM_OPT='--notest' PLENV_INSTALL_CPANM=' ' ${plenv_root}/bin/plenv install-cpanm"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos6.6
 
-ARG plenv_root=/opt/.plenv
+ARG plenv_root=/opt/plenv
 ARG plenv_version=2.2.0
 ARG plenv_perlbuild_version=1.13
 


### PR DESCRIPTION
During the build process for Perl-based CHS projects, generated binaries will include a path to the plenv-managed Perl interpreter on the host machine. For example:

In Vagrant environments:

```
#!/home/vagrant/.plenv/versions/5.18.2/bin/perl5.18.2
```

In Jenkins:

```
#!/opt/plenv/versions/5.18.2/bin/perl5.18.2
```

When using prebuilt dependency packages, and given that this path can differ between environments, there **must be consistency** between our CI environment(s) and production environment else the resulting files will not be portable and will fail with a `bad interpreter` error.

The change in this pull-request sets the install root to `/opt/plenv` for our Perl CI build image—used in Concourse—to match that of our production environment. A pull-request for Vagrant environments will be raised at a later date (this is low priority as no artefacts generated from local builds should ever make it into our production environment).

Resolves: DVOP-907